### PR TITLE
Fixes for issues 22 and 24

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,14 @@ repos:
         args: [--debug]
         always_run: true
         pass_filenames: false
-  # - repo: https://github.com/shellcheck-py/shellcheck-py
-  #   rev: v0.8.0.4
-  #   hooks:
-  #     - id: shellcheck
-  #       name: Check shell scripts with shellcheck
-  #       files: ^.*\.(sh|bash|ksh)$
-  #       types: []
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.8.0.4
+    hooks:
+      - id: shellcheck
+        name: Check shell scripts with shellcheck
+        args: [--severity=error]
+        files: ^.*\.(sh|bash|ksh)$
+        types: []
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.26.3
     hooks:

--- a/pillar/top.sls
+++ b/pillar/top.sls
@@ -21,3 +21,4 @@ base:
   'osw-devops-ci':
     # Overrides for Kitchen testing
     - test.nginx
+    - test.supervisor

--- a/salt/backup/files/backup_site.sh
+++ b/salt/backup/files/backup_site.sh
@@ -9,8 +9,7 @@ SITE_DIR="www"
 CONFIGS="{{backup_config_list}}"
 
 function create_backup {
-  nice -n 19 ionice -c3 tar cfz ${BACKUP_DIR}/${1}.tgz -C / ${SITE_DIR}/${1}/htdocs
-  {%- for exclude in pillar['backup_exclude_from_sites'] -%}{{' '}}--exclude="{{exclude}}"{% endfor %}
+  nice -n 19 ionice -c3 tar {%- for exclude in pillar['backup_exclude_from_sites'] -%}{{' '}}--exclude="{{exclude}}"{% endfor %} -cfz ${BACKUP_DIR}/${1}.tgz -C / ${SITE_DIR}/${1}/htdocs
 }
 
 mkdir -p ${BACKUP_DIR}

--- a/salt/certbot/init.sls
+++ b/salt/certbot/init.sls
@@ -1,7 +1,7 @@
+include:
+  - renew
+
 certbot-pkg:
   pkg.latest:
     - name: certbot
     - refresh: True
-
-include:
-  - letsencrypt

--- a/salt/certbot/renew.sls
+++ b/salt/certbot/renew.sls
@@ -1,4 +1,4 @@
 cerbot-renew-cert:
   file.append:
     - name: /etc/letsencrypt/cli.ini
-    - text: deploy-hook = systemctl reload nginx
+    - text: deploy-hook = nginx -s reload

--- a/test/salt/pillar/test/supervisor.sls
+++ b/test/salt/pillar/test/supervisor.sls
@@ -1,0 +1,10 @@
+# vim: ft=yaml
+# !!!!!!!!!!!!!!!!!!!!!!!!!! TEST STATE !!!!!!!!!!!!!!!!!!!!!!!!!!!
+# THIS SHOULD NOT BE USED OUTSIDE OF KITCHEN TESTING
+#
+# Test pillar to prevent run
+# "/usr/bin/php -q /www/opensourcewebsite.org/htdocs/yii cron"
+---
+supervisor:
+    opensourcewebsite-cron:
+      command: sleep infinity


### PR DESCRIPTION
- Severity for `shellcheck` has been changed to `error`
- Fix excludes for `tar`
- Stub `opensourcewebsite-cron` in `supervisor` for testing purposes