### PR TITLE
Fixes warnings about `replace` with no `contents` defined

### DIFF
--- a/salt/sudoers.sls
+++ b/salt/sudoers.sls
@@ -1,7 +1,7 @@
 /etc/sudoers.d/custom:
   file.managed:
     - mode: 440
-    - content: Defaults !mail_no_user
+    - contents: Defaults !mail_no_user
     - check_cmd: /usr/sbin/visudo -cf
     - require:
       - pkg: sudo

--- a/salt/update_motd_d/init.sls
+++ b/salt/update_motd_d/init.sls
@@ -5,6 +5,7 @@
     - group: root
     - mode: 644
     - create: False
+    - replace: False
 
 /etc/update-motd.d/51-cloudguest:
   file.managed:
@@ -13,6 +14,7 @@
     - group: root
     - mode: 644
     - create: False
+    - replace: False
 
 create_htpasswd:
   file.line:


### PR DESCRIPTION
Fix for this warnings:
```
[WARNING ] State for file: /etc/sudoers.d/custom - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
[WARNING ] State for file: /etc/update-motd.d/10-help-text - Neither 'source' nor 'contents' nor 'contents_pillar' nor 'contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
[WARNING ] State for file: /etc/update-motd.d/51-cloudguest - Neither 'source' nor 'contents' nor 'contents_pillar' nor contents_grains' was defined, yet 'replace' was set to 'True'. As there is no source to replace the file with, 'replace' has been set to 'False' to avoid reading the file unnecessarily.
```